### PR TITLE
add bizhawk .SaveRAM extension to auto update file picker filter

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -136,7 +136,7 @@
             // openFileDialog1
             // 
             this.openFileDialog1.FileName = "openFileDialog1";
-            this.openFileDialog1.Filter = "SRAM Files|*.srm";
+            this.openFileDialog1.Filter = "SRAM Files|*.srm;*.SaveRAM";
             // 
             // timer1
             // 


### PR DESCRIPTION
bizhawk uses the .SaveRAM extension instead of .srm, so I added it to the filter on the autoupdate save file picker.